### PR TITLE
B_PANAIFO: Agregar SQL schemas, datos de prueba, verificación y docum…

### DIFF
--- a/docs/grupo_3/B_PANAIFO/01_B_PANAIFO_BORRADOR_SQL.sql
+++ b/docs/grupo_3/B_PANAIFO/01_B_PANAIFO_BORRADOR_SQL.sql
@@ -1,0 +1,174 @@
+/*
+=========================================================
+B_PANAIFO - BORRADOR SQL
+Módulo de Organización, Roles y Permisos
+
+PostgreSQL 18.6
+
+IMPORTANTE:
+Este script es un BORRADOR técnico.
+No representa decisiones institucionales definitivas.
+Los datos reales NO deben utilizarse en este archivo.
+=========================================================
+*/
+
+-- ======================================================
+-- 1. TABLA: AREAS
+-- ======================================================
+
+CREATE TABLE areas (
+    id BIGSERIAL PRIMARY KEY,
+    nombre VARCHAR(150) NOT NULL,
+    sigla VARCHAR(20) NOT NULL UNIQUE,
+    parent_id BIGINT,
+    estado BOOLEAN NOT NULL DEFAULT TRUE,
+
+    CONSTRAINT fk_areas_parent
+        FOREIGN KEY (parent_id)
+        REFERENCES areas(id)
+);
+
+-- Índice para consultas de jerarquía
+CREATE INDEX idx_areas_parent_id
+    ON areas(parent_id);
+
+
+-- ======================================================
+-- 2. TABLA: CARGOS
+-- ======================================================
+
+CREATE TABLE cargos (
+    id BIGSERIAL PRIMARY KEY,
+    nombre VARCHAR(100) NOT NULL UNIQUE,
+    estado BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+
+-- ======================================================
+-- 3. TABLA: RESPONSABLES
+-- ======================================================
+
+/*
+NOTA:
+users(id) pertenece a una estructura externa al módulo.
+Por eso esta tabla depende de que users exista.
+*/
+
+CREATE TABLE responsables (
+    id BIGSERIAL PRIMARY KEY,
+    area_id BIGINT NOT NULL,
+    usuario_id BIGINT NOT NULL,
+    cargo_id BIGINT NOT NULL,
+    fecha_inicio DATE NOT NULL,
+    fecha_fin DATE,
+    es_titular BOOLEAN NOT NULL DEFAULT TRUE,
+
+    CONSTRAINT fk_responsables_area
+        FOREIGN KEY (area_id)
+        REFERENCES areas(id),
+
+    CONSTRAINT fk_responsables_cargo
+        FOREIGN KEY (cargo_id)
+        REFERENCES cargos(id),
+
+    CONSTRAINT chk_responsables_fechas
+        CHECK (
+            fecha_fin IS NULL
+            OR fecha_fin >= fecha_inicio
+        )
+);
+
+-- Índices para consultas frecuentes
+CREATE INDEX idx_responsables_area
+    ON responsables(area_id);
+
+CREATE INDEX idx_responsables_usuario
+    ON responsables(usuario_id);
+
+CREATE INDEX idx_responsables_cargo
+    ON responsables(cargo_id);
+
+CREATE INDEX idx_responsables_vigencia
+    ON responsables(fecha_inicio, fecha_fin);
+
+
+-- ======================================================
+-- 4. TABLA: ROLES
+-- ======================================================
+
+CREATE TABLE roles (
+    id BIGSERIAL PRIMARY KEY,
+    codigo VARCHAR(50) NOT NULL UNIQUE,
+    nombre VARCHAR(100) NOT NULL
+);
+
+
+-- ======================================================
+-- 5. TABLA: PERMISOS
+-- ======================================================
+
+CREATE TABLE permisos (
+    id BIGSERIAL PRIMARY KEY,
+    codigo VARCHAR(100) NOT NULL UNIQUE,
+    descripcion TEXT
+);
+
+
+-- ======================================================
+-- 6. TABLA: ROLES_PERMISOS
+-- Relación muchos a muchos
+-- ======================================================
+
+CREATE TABLE roles_permisos (
+    rol_id BIGINT NOT NULL,
+    permiso_id BIGINT NOT NULL,
+
+    CONSTRAINT pk_roles_permisos
+        PRIMARY KEY (rol_id, permiso_id),
+
+    CONSTRAINT fk_roles_permisos_rol
+        FOREIGN KEY (rol_id)
+        REFERENCES roles(id),
+
+    CONSTRAINT fk_roles_permisos_permiso
+        FOREIGN KEY (permiso_id)
+        REFERENCES permisos(id)
+);
+
+-- Índice para búsquedas de permisos por permiso
+CREATE INDEX idx_roles_permisos_permiso
+    ON roles_permisos(permiso_id);
+
+
+/*
+=========================================================
+NOTAS TÉCNICAS
+=========================================================
+
+1. areas.parent_id permite representar una jerarquía
+   ilimitada mediante una referencia a la misma tabla.
+
+2. Un CHECK puede evitar casos simples, pero no puede
+   garantizar por sí solo que no existan ciclos como:
+
+       A -> B -> C -> A
+
+   La prevención completa de ciclos puede requerir
+   lógica adicional mediante trigger, función o
+   validación de aplicación.
+
+3. roles_permisos representa la relación N:M entre roles
+   y permisos mediante identificadores.
+
+4. No se almacenan permisos como listas separadas
+   por comas.
+
+5. responsables mantiene historial mediante
+   fecha_inicio y fecha_fin.
+
+6. usuario_id depende de la tabla externa users(id).
+
+7. Este script es PROVISIONAL y no contiene datos
+   personales, credenciales ni contraseñas reales.
+=========================================================
+*/

--- a/docs/grupo_3/B_PANAIFO/02_B_PANAIFO_DATOS_PRUEBA.sql
+++ b/docs/grupo_3/B_PANAIFO/02_B_PANAIFO_DATOS_PRUEBA.sql
@@ -1,0 +1,89 @@
+/*
+=========================================================
+B_PANAIFO - DATOS DE PRUEBA
+Módulo de Organización, Roles y Permisos
+
+TODOS LOS DATOS SON FICTICIOS Y NO OFICIALES
+=========================================================
+*/
+
+-- ======================================================
+-- ÁREAS
+-- ======================================================
+
+INSERT INTO areas (nombre, sigla, parent_id, estado)
+VALUES
+('Dirección General de Prueba', 'DGP', NULL, TRUE);
+
+INSERT INTO areas (nombre, sigla, parent_id, estado)
+VALUES
+('Oficina de Administración de Prueba', 'OAP', 1, TRUE),
+('Oficina de Sistemas de Prueba', 'OSP', 1, TRUE),
+('Oficina de Archivo de Prueba', 'OAR', 1, TRUE);
+
+INSERT INTO areas (nombre, sigla, parent_id, estado)
+VALUES
+('Área de Desarrollo de Prueba', 'ADP', 3, TRUE);
+
+
+-- ======================================================
+-- CARGOS
+-- ======================================================
+
+INSERT INTO cargos (nombre, estado)
+VALUES
+('Director de Prueba', TRUE),
+('Jefe de Oficina de Prueba', TRUE),
+('Especialista de Prueba', TRUE),
+('Analista de Prueba', TRUE);
+
+
+-- ======================================================
+-- ROLES
+-- ======================================================
+
+INSERT INTO roles (codigo, nombre)
+VALUES
+('ROLE_ADMIN', 'Administrador de Prueba'),
+('ROLE_OPERADOR', 'Operador de Prueba'),
+('ROLE_CONSULTA', 'Consulta de Prueba');
+
+
+-- ======================================================
+-- PERMISOS
+-- ======================================================
+
+INSERT INTO permisos (codigo, descripcion)
+VALUES
+('area:crear', 'Crear un área'),
+('area:consultar', 'Consultar áreas'),
+('area:editar', 'Editar información de un área'),
+('area:eliminar', 'Eliminar un área'),
+('usuario:consultar', 'Consultar información de usuarios'),
+('permiso:gestionar', 'Gestionar permisos');
+
+
+-- ======================================================
+-- RELACIÓN ROLES - PERMISOS
+-- ======================================================
+
+-- Administrador
+INSERT INTO roles_permisos (rol_id, permiso_id)
+VALUES
+(1, 1),
+(1, 2),
+(1, 3),
+(1, 4),
+(1, 5),
+(1, 6);
+
+-- Operador
+INSERT INTO roles_permisos (rol_id, permiso_id)
+VALUES
+(2, 2),
+(2, 3);
+
+-- Consulta
+INSERT INTO roles_permisos (rol_id, permiso_id)
+VALUES
+(3, 2);

--- a/docs/grupo_3/B_PANAIFO/03_B_PANAIFO_VERIFICACION.sql
+++ b/docs/grupo_3/B_PANAIFO/03_B_PANAIFO_VERIFICACION.sql
@@ -1,0 +1,75 @@
+/*
+=========================================================
+B_PANAIFO - VERIFICACIÓN
+Módulo de Organización, Roles y Permisos
+
+Consultas para demostrar que las tablas y relaciones funcionan
+=========================================================
+*/
+
+-- ================================================
+-- VERIFICACIÓN DE ÁREAS
+-- ================================================
+
+SELECT *
+FROM areas
+ORDER BY id;
+
+
+-- ================================================
+-- VERIFICACIÓN DE CARGOS
+-- ================================================
+
+SELECT *
+FROM cargos
+ORDER BY id;
+
+
+-- ================================================
+-- VERIFICACIÓN DE ROLES
+-- ================================================
+
+SELECT *
+FROM roles
+ORDER BY id;
+
+
+-- ================================================
+-- VERIFICACIÓN DE PERMISOS
+-- ================================================
+
+SELECT *
+FROM permisos
+ORDER BY id;
+
+
+-- ================================================
+-- VERIFICACIÓN DE ROLES Y PERMISOS
+-- ================================================
+
+SELECT
+    r.codigo AS rol,
+    r.nombre AS nombre_rol,
+    p.codigo AS permiso,
+    p.descripcion
+FROM roles_permisos rp
+INNER JOIN roles r
+    ON r.id = rp.rol_id
+INNER JOIN permisos p
+    ON p.id = rp.permiso_id
+ORDER BY r.id, p.id;
+
+
+-- ================================================
+-- VERIFICACIÓN ROLE_CONSULTA
+-- ================================================
+
+SELECT
+    r.codigo AS rol,
+    p.codigo AS permiso
+FROM roles_permisos rp
+JOIN roles r
+    ON r.id = rp.rol_id
+JOIN permisos p
+    ON p.id = rp.permiso_id
+WHERE r.codigo = 'ROLE_CONSULTA';

--- a/docs/grupo_3/B_PANAIFO/04_B_PANAIFO_VALIDACION.md
+++ b/docs/grupo_3/B_PANAIFO/04_B_PANAIFO_VALIDACION.md
@@ -1,0 +1,97 @@
+| ID  | Rol             | Acción              | Resultado esperado |
+|-----|-----------------|---------------------|--------------------|
+| V01 | ROLE_ADMIN      | Consultar área      | PERMITIDO          |
+| V02 | ROLE_ADMIN      | Crear área          | PERMITIDO          |
+| V03 | ROLE_ADMIN      | Editar área         | PERMITIDO          |
+| V04 | ROLE_ADMIN      | Eliminar área       | PERMITIDO          |
+| V05 | ROLE_ADMIN      | Gestionar permisos  | PERMITIDO          |
+| V06 | ROLE_OPERADOR   | Consultar área      | PERMITIDO          |
+| V07 | ROLE_OPERADOR   | Editar área         | PERMITIDO          |
+| V08 | ROLE_OPERADOR   | Eliminar área       | DENEGADO           |
+| V09 | ROLE_OPERADOR   | Gestionar permisos  | DENEGADO           |
+| V10 | ROLE_CONSULTA   | Consultar área      | PERMITIDO          |
+| V11 | ROLE_CONSULTA   | Crear área          | DENEGADO           |
+| V12 | ROLE_CONSULTA   | Editar área         | DENEGADO           |
+| V13 | ROLE_CONSULTA   | Eliminar área       | DENEGADO           |
+| V14 | ROLE_CONSULTA   | Gestionar permisos  | DENEGADO           |
+
+## Casos de prueba
+
+### Caso PERMITIDO - ROLE_CONSULTA puede consultar áreas
+
+```sql
+SELECT
+    r.codigo AS rol,
+    p.codigo AS permiso
+FROM roles_permisos rp
+JOIN roles r ON r.id = rp.rol_id
+JOIN permisos p ON p.id = rp.permiso_id
+WHERE r.codigo = 'ROLE_CONSULTA';
+```
+
+**Resultado esperado:**
+```
+ROLE_CONSULTA | area:consultar
+```
+
+### Caso DENEGADO - ROLE_CONSULTA no puede crear áreas
+
+ROLE_CONSULTA solamente tiene permiso `area:consultar`. No tiene permiso `area:crear`.
+
+**Resultado esperado:** DENEGADO
+
+## Pruebas de restricciones
+
+### Prueba UNIQUE - roles.codigo
+
+```sql
+INSERT INTO roles (codigo, nombre)
+VALUES ('ROLE_ADMIN', 'Otro administrador');
+```
+
+**Resultado esperado:** Falla (error UNIQUE violation)
+
+### Prueba CHECK - responsables.fechas
+
+```sql
+INSERT INTO responsables
+(area_id, usuario_id, cargo_id, fecha_inicio, fecha_fin)
+VALUES
+(1, 1001, 1, '2026-08-30', '2026-08-01');
+```
+
+**Resultado esperado:** Falla (CHECK violation: fecha_fin < fecha_inicio)
+
+### Prueba de Foreign Key
+
+```sql
+INSERT INTO roles_permisos
+(rol_id, permiso_id)
+VALUES
+(9999, 9999);
+```
+
+**Resultado esperado:** Falla (Foreign key violation)
+
+## Prueba de la relación muchos a muchos
+
+ROLE_ADMIN debe tener múltiples permisos:
+
+```sql
+SELECT
+    r.codigo AS rol,
+    COUNT(p.id) AS total_permisos,
+    STRING_AGG(p.codigo, ', ' ORDER BY p.codigo) AS permisos
+FROM roles_permisos rp
+JOIN roles r ON r.id = rp.rol_id
+JOIN permisos p ON p.id = rp.permiso_id
+WHERE r.codigo = 'ROLE_ADMIN'
+GROUP BY r.id, r.codigo;
+```
+
+**Resultado esperado:**
+```
+ROLE_ADMIN | 6 | area:consultar, area:crear, area:editar, area:eliminar, permiso:gestionar, usuario:consultar
+```
+
+Los permisos se relacionan mediante identificadores (rol_id, permiso_id) en roles_permisos, no mediante texto duplicado.

--- a/docs/grupo_3/B_PANAIFO/05_B_PANAIFO_NOTAS_TECNICAS.md
+++ b/docs/grupo_3/B_PANAIFO/05_B_PANAIFO_NOTAS_TECNICAS.md
@@ -1,0 +1,336 @@
+# B_PANAIFO - Notas Técnicas
+## Módulo de Organización, Roles y Permisos
+
+---
+
+## 1. Estructura de Áreas Jerárquicas
+
+### Concepto
+
+La tabla `areas` utiliza el patrón de **autorreferencia** para representar una estructura jerárquica ilimitada:
+
+```sql
+parent_id BIGINT REFERENCES areas(id)
+```
+
+### Ejemplo de jerarquía
+
+```
+Dirección General (id=1, parent_id=NULL)
+   │
+   ├── Oficina de Administración (id=2, parent_id=1)
+   ├── Oficina de Sistemas (id=3, parent_id=1)
+   └── Oficina de Archivo (id=4, parent_id=1)
+          │
+          └── Área de Desarrollo (id=5, parent_id=3)
+```
+
+### Ventajas
+
+- Permite jerarquías de **profundidad ilimitada**
+- Flexibilidad para reorganizaciones
+- Una sola tabla, sin necesidad de crear múltiples niveles predefinidos
+
+### Limitaciones
+
+- Las consultas de jerarquía completa requieren **CTEs recursivas** o funciones especiales
+- PostgreSQL no impide ciclos indirectos a nivel de restricción
+
+---
+
+## 2. Prevención de Ciclos en la Jerarquía
+
+### Problema
+
+La restricción de clave foránea garantiza que `parent_id` apunte a un área existente, pero **no puede evitar ciclos indirectos**:
+
+```
+Ciclo indirecto no detectado:
+A → B → C → A
+```
+
+### Soluciones propuestas
+
+#### Opción 1: Función de validación en la aplicación
+
+```python
+def has_cycle(area_id, parent_id, db):
+    """Verifica si establecer parent_id crearía un ciclo"""
+    visited = set()
+    current = parent_id
+    while current is not None:
+        if current == area_id:
+            return True  # Ciclo detectado
+        visited.add(current)
+        parent = db.get_parent(current)
+        if parent in visited:
+            return True  # Ciclo detectado
+        current = parent
+    return False
+```
+
+#### Opción 2: Trigger de PostgreSQL
+
+```sql
+CREATE OR REPLACE FUNCTION check_area_cycle()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Lógica recursiva para detectar ciclos
+    -- ...
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_check_area_cycle
+    BEFORE INSERT OR UPDATE ON areas
+    FOR EACH ROW
+    EXECUTE FUNCTION check_area_cycle();
+```
+
+#### Opción 3: Consulta recursiva en validación
+
+```sql
+WITH RECURSIVE area_hierarchy AS (
+    SELECT id, parent_id FROM areas WHERE id = $1
+    UNION ALL
+    SELECT a.id, a.parent_id
+    FROM areas a
+    INNER JOIN area_hierarchy ah ON a.id = ah.parent_id
+)
+SELECT COUNT(*) FROM area_hierarchy WHERE id = $2;
+```
+
+### Decisión actual
+
+**Prevención de ciclos: La tabla `areas` no implementa validación de ciclos a nivel de base de datos.** Una prevención completa requiere lógica adicional mediante trigger, función o validación en la aplicación.
+
+---
+
+## 3. Estados y Vigencias
+
+### Tabla: `areas`
+
+- **estado**: `BOOLEAN` (TRUE = activo, FALSE = inactivo)
+- Permite marcar áreas como inactivas sin eliminarlas
+
+### Tabla: `responsables`
+
+- **fecha_inicio**: Inicio de responsabilidad (obligatorio)
+- **fecha_fin**: Fin de responsabilidad (NULL = vigente)
+- **es_titular**: Indica si el responsable es titular o suplente
+
+#### Ejemplo de historial
+
+```
+Área: Sistemas
+│
+├── Usuario: 1001, Cargo: Director, Inicio: 01/01/2026, Fin: NULL
+│   (Responsable actual)
+│
+├── Usuario: 1002, Cargo: Director, Inicio: 01/06/2025, Fin: 31/12/2025
+│   (Responsable histórico)
+```
+
+#### Restricción CHECK
+
+```sql
+CONSTRAINT chk_responsables_fechas
+    CHECK (
+        fecha_fin IS NULL
+        OR fecha_fin >= fecha_inicio
+    )
+```
+
+Garantiza que `fecha_fin` no sea anterior a `fecha_inicio`.
+
+---
+
+## 4. Relación Muchos a Muchos (N:M)
+
+### Diseño: roles_permisos
+
+```
+roles (1) ──→ roles_permisos ←── (M) permisos
+                    │
+         (rol_id, permiso_id)
+```
+
+**Ventajas:**
+
+- Permite que un rol tenga múltiples permisos
+- Permite que un permiso sea asignado a múltiples roles
+- Evita datos duplicados (sin listas separadas por comas)
+- Fácil mantenimiento y escalabilidad
+
+**Ejemplo:**
+
+```
+ROLE_ADMIN tiene: area:crear, area:consultar, area:editar, area:eliminar
+ROLE_OPERADOR tiene: area:consultar, area:editar
+ROLE_CONSULTA tiene: area:consultar
+```
+
+En `roles_permisos`:
+
+```
+(rol_id=1, permiso_id=1)  → ROLE_ADMIN puede area:crear
+(rol_id=1, permiso_id=2)  → ROLE_ADMIN puede area:consultar
+(rol_id=2, permiso_id=2)  → ROLE_OPERADOR puede area:consultar
+(rol_id=3, permiso_id=2)  → ROLE_CONSULTA puede area:consultar
+```
+
+---
+
+## 5. Índices para Optimización
+
+### Índices creados
+
+| Tabla | Índice | Propósito |
+|-------|--------|-----------|
+| areas | idx_areas_parent_id | Consultas de jerarquía |
+| responsables | idx_responsables_area | Filtrar responsables por área |
+| responsables | idx_responsables_usuario | Filtrar responsables por usuario |
+| responsables | idx_responsables_cargo | Filtrar responsables por cargo |
+| responsables | idx_responsables_vigencia | Consultas de vigencia (fecha_inicio, fecha_fin) |
+| roles_permisos | idx_roles_permisos_permiso | Búsquedas de permisos por permiso |
+
+### Justificación
+
+- Mejoran el rendimiento de consultas frecuentes
+- Reducen tiempos de escaneo de tablas
+- Especialmente importantes en `responsables` por las consultas de vigencia
+
+---
+
+## 6. Dependencia Externa: usuarios (users)
+
+### Problema
+
+La tabla `responsables` incluye:
+
+```sql
+usuario_id BIGINT NOT NULL
+```
+
+Pero la tabla `users` **no pertenece al módulo B_PANAIFO**. Viene de otro componente/módulo del sistema.
+
+### Decisión actual
+
+**La FK de `usuario_id` → `users(id)` no está creada en este script.**
+
+Razón: La tabla `users` no fue incluida en el modelo proporcionado por B_POOL.
+
+### Acción requerida
+
+Cuando la tabla `users` esté disponible y aprobada, agregar:
+
+```sql
+ALTER TABLE responsables
+ADD CONSTRAINT fk_responsables_usuario
+    FOREIGN KEY (usuario_id)
+    REFERENCES users(id);
+```
+
+### Nota para documentación
+
+**Dependencia externa:** `responsables.usuario_id` referencia `users(id)`, tabla perteneciente a otro componente/módulo del sistema. La creación definitiva de esta FK depende de que la tabla `users` y su clave primaria estén disponibles y aprobadas.
+
+---
+
+## 7. Restricciones de Integridad
+
+### UNIQUE
+
+- **areas.sigla**: Cada área debe tener una sigla única (ej: "DGP", "OSP")
+- **cargos.nombre**: Cada cargo debe tener nombre único
+- **roles.codigo**: Cada rol debe tener código único (ej: "ROLE_ADMIN")
+- **permisos.codigo**: Cada permiso debe tener código único (ej: "area:crear")
+
+### FOREIGN KEYS
+
+- **areas.parent_id** → areas(id): Asegura que el área padre existe
+- **responsables.area_id** → areas(id): Asegura que el área existe
+- **responsables.cargo_id** → cargos(id): Asegura que el cargo existe
+- **roles_permisos.rol_id** → roles(id): Asegura que el rol existe
+- **roles_permisos.permiso_id** → permisos(id): Asegura que el permiso existe
+
+### CHECK
+
+- **responsables.chk_responsables_fechas**: Valida que fecha_fin >= fecha_inicio (o sea NULL)
+
+---
+
+## 8. Datos Ficticios y Pruebas
+
+### Nota importante
+
+**TODOS LOS DATOS SON FICTICIOS Y NO OFICIALES.**
+
+- No se incluyen datos personales reales
+- No se incluyen credenciales ni contraseñas
+- Los IDs utilizados son solo para demostración
+
+### Orden de ejecución recomendado
+
+1. **01_B_PANAIFO_BORRADOR_SQL.sql**: Crear tablas
+2. **02_B_PANAIFO_DATOS_PRUEBA.sql**: Insertar datos ficticios
+3. **03_B_PANAIFO_VERIFICACION.sql**: Ejecutar consultas de verificación
+4. **04_B_PANAIFO_VALIDACION.md**: Revisar matriz de validación
+
+---
+
+## 9. Limitaciones y Consideraciones
+
+### Ciclos en la jerarquía
+
+Como se mencionó en la sección 2, no hay prevención de ciclos a nivel de BD.
+
+### Histórico de cambios
+
+No existe auditoría automática. Para implementarla:
+
+```sql
+CREATE TABLE areas_audit (
+    id BIGSERIAL PRIMARY KEY,
+    area_id BIGINT,
+    accion VARCHAR(50),
+    datos_anteriores JSONB,
+    datos_nuevos JSONB,
+    fecha_cambio TIMESTAMP DEFAULT NOW()
+);
+```
+
+### Eliminación de áreas
+
+Actualmente no existe CASCADE DELETE. Borrar un área requiere:
+
+1. Reasignar responsables
+2. Reasignar áreas hijas o cambiar parent_id
+3. Luego sí eliminar el área
+
+---
+
+## 10. Características del BORRADOR
+
+Este script es **PROVISIONAL**:
+
+- ✅ Tablas, PK, FK, UNIQUE, CHECK e índices funcionales
+- ✅ Datos ficticios para demostración
+- ✅ Consultas de verificación y validación
+- ⏳ Pendiente: Integración real con módulo `users`
+- ⏳ Pendiente: Implementación de auditoría
+- ⏳ Pendiente: Lógica de prevención de ciclos
+- ⏳ Pendiente: Validaciones complejas en triggers
+
+---
+
+## Referencias
+
+- **Modelo base**: B_POOL (diccionario y propuesta de tablas)
+- **Base de datos**: PostgreSQL 18.6
+- **Estándar**: SQL ISO/IEC 9075
+
+---
+
+**Fecha de elaboración:** 2026-08-28  
+**Versión:** 1.0 (BORRADOR)


### PR DESCRIPTION
## B_PANAIFO - Módulo de Organización, Roles y Permisos
### Grupo 3

**Rama:** B_PANAIFO

Tomé el diccionario y modelo propuesto por B_POOL y elaboré el borrador SQL para PostgreSQL 18.6.

Implementé las 6 tablas del módulo:
- **areas**: estructura jerárquica mediante autorreferencia
- **cargos**: catálogo de cargos
- **responsables**: historial de responsables con vigencia
- **roles**: roles del sistema
- **permisos**: permisos disponibles
- **roles_permisos**: relación N:M

Agregué claves primarias, foráneas, restricciones UNIQUE y CHECK para integridad de datos, más índices en columnas consultadas frecuentemente.

Preparé datos ficticios NO oficiales: 5 áreas jerárquicas, 4 cargos, 3 roles, 6 permisos con relaciones diferenciadas por rol.

Elaboré consultas de verificación para demostrar funcionamiento de tablas y relaciones.

Creé matriz de validación con 14 casos de prueba (PERMITIDO/DENEGADO) y pruebas de restricciones.

Incluí documentación técnica: jerarquía de áreas, limitación de ciclos (requiere lógica adicional), vigencias e historial, relación N:M, índices, y dependencia externa de users.

**5 archivos entregados:**
1. 01_B_PANAIFO_BORRADOR_SQL.sql - SQL schemas
2. 02_B_PANAIFO_DATOS_PRUEBA.sql - Datos ficticios  
3. 03_B_PANAIFO_VERIFICACION.sql - Consultas verificación
4. 04_B_PANAIFO_VALIDACION.md - Matriz validación
5. 05_B_PANAIFO_NOTAS_TECNICAS.md - Documentación técnica