### PR TITLE
docs(identicore): cerrar H1 y corregir observaciones documentalesdocs(identicore): corregir y cerrar H1

### DIFF
--- a/backend/docs/README.md
+++ b/backend/docs/README.md
@@ -34,7 +34,7 @@ Todos los módulos del backend han sido auditados contra las listas de verificac
 | **Grupo 1 — RutaDoc**<br>*(Trazabilidad, Recepción, Derivación, Atención)* | Geric (`B_GERIC`), Jacobo (`B_JACOBO`), Jhasy (`B_JHASY`) | **11 / 11** (100%) | ✅ **CONFORME** |
 | **Grupo 2 — TramiCore**<br>*(Trámite, Expediente, Libro de Registro)* | Ramírez (`B_RAMIREZ`), Riquelmer (`B_RIQUELMER`), Sandy (`B_SANDY`) | **10 / 10** (100%) | ✅ **CONFORME** |
 | **Grupo 3 — OrganiCore**<br>*(Áreas, Jerarquías, Roles, Permisos RBAC)* | Pool (`B_POOL`), Leonardo (`B_LEONARDO`), Panaifo (`B_PANAIFO`), Héctor (`B_HECTOR`) | **10 / 10** (100%) | ✅ **CONFORME** |
-| **Grupo 4 — IdentiCore**<br>*(Personas, Cuentas, Usuarios Internos/Externos)* | Segundo (`B_SEGUNDO`), Tapullima (`B_TAPULLIMA`), Jair (`B_JAIR`) | **10 / 10** (100%) | ✅ **CONFORME** |
+| **Grupo 4 — IdentiCore**<br>*(Personas, Cuentas, Usuarios Internos/Externos)* | Segundo (`B_SEGUNDO`), Tapullima (`B_TAPULLIMA`), Jair (`B_JAIR`) | **Pendiente de validación H4** | ⚠️ **OBSERVADO / PENDIENTE DE VALIDACIÓN** |
 | **Grupo 5 — DocuCore**<br>*(Catálogo TUPA, Requisitos, Formularios)* | Cristian (`B_CHRISTIAN`), Azareño (`B_AZAREÑO`), Valentín (`B_VALENTIN`), Piero (`B_PIERO`) | **14 / 14** (100%) | ✅ **CONFORME** |
 | **Grupo 6 — CoreLink**<br>*(Integración, Catálogo Errores, Pruebas E2E)* | Ricardo (`B_AREVALO`), Duque (`B_DUQUE`), Reátegui (`B_REATEGUI`), Zevallos (`B_ZEVALLOS`) | **7 / 7** (100%) | ✅ **CONFORME** |
 | **TOTAL CONSOLIDADO** | **Equipo Completo de Desarrollo Backend** | **Requiere actualización por módulo** | ⚠️ **NO CONCLUIDO** |
@@ -105,7 +105,7 @@ Responsable de representar áreas institucionales, jerarquías recursivas, cargo
 ### Grupo 4 — IdentiCore · Usuarios Internos y Externos
 Responsable del desacoplamiento entre Persona Natural/Jurídica, Cuenta de Usuario y clasificación de solicitantes internos, externos registrados y externos en ventanilla.
 
-* 📘 **Análisis Funcional:** [`identicore/01_analisis_usuarios_internos_externos.md`](identicore/01_analisis_usuarios_internos_externos.md)
+* 📘 **Análisis Funcional:** [`levantamiento_de_observaciones/01_analisis_usuarios_internos_externos.md`](levantamiento_de_observaciones/01_analisis_usuarios_internos_externos.md)
 * 📐 **Modelo de Datos Lógico:** [`identicore/02_modelo_datos_usuarios.md`](identicore/02_modelo_datos_usuarios.md)
 * 📖 **Diccionario de Datos:** [`identicore/02_diccionario_datos_usuarios.md`](identicore/02_diccionario_datos_usuarios.md)
 * 📊 **Diagramas del Modelo ER:** [Editable Draw.io (`.drawio`)](identicore/02_modelo_datos_usuarios_diagrama.drawio) · [Vista previa (`.png`)](identicore/02_modelo_datos_usuarios_diagrama.png)

--- a/backend/docs/levantamiento_de_observaciones/01_analisis_identidad_personas_seguridad.md
+++ b/backend/docs/levantamiento_de_observaciones/01_analisis_identidad_personas_seguridad.md
@@ -34,7 +34,7 @@ IdentiCore administra:
 ### 2.2 Exclusiones de esta fase
 
 - No se realizarán consultas activas con costo a RENIEC PIDE, SUNAT ni SUNARP.
-- Se usarán adaptadores simulados (Mock Services) para validar estructura, formato y checksum de DNI/RUC.
+- Se usarán adaptadores simulados (Mock Services) como requisito de validación de estructura, formato y checksum de DNI/RUC; su ejecución y evidencia quedan **PENDIENTES**.
 - La aprobación institucional de roles, permisos, plazos operativos y textos legales queda sujeta a validación del IESTP "Suiza".
 
 ## 3. Clasificación oficial y unificada de usuarios
@@ -72,7 +72,7 @@ La siguiente clasificación es la única nomenclatura oficial del módulo. No de
 | `sesion_usuario` | Ciclo de vida de sesiones y refresh tokens rotativos. | Familia de token, expiración y revocación |
 | `consentimiento_datos` | Evidencia versionada de aceptación o revocación. | Persona, finalidad, versión y fecha UTC |
 
-### 4.2 Regla de herencia exclusiva 1:1
+### 4.2 Regla de herencia exclusiva y unicidad de representación
 
 La herencia se implementará mediante tablas relacionadas, no mediante herencia física de PostgreSQL.
 
@@ -83,7 +83,7 @@ La herencia se implementará mediante tablas relacionadas, no mediante herencia 
 - La consistencia entre el discriminador y el subtipo se validará con restricciones y triggers diferibles o una función transaccional de alta, de modo que no pueda quedar una persona sin subtipo ni con dos subtipos al finalizar la transacción.
 - No se permitirá cambiar `tipo_persona` si el cambio deja datos de subtipo incompatibles.
 
-**Estado:** `CONFIRMADO`.  
+**Estado:** `PROPUESTO` / `PENDIENTE`.
 **Implementación detallada del DDL:** `PROPUESTO`, a cargo de `B_SEGUNDO`.
 
 ### 4.3 Identificadores y unicidad
@@ -118,8 +118,9 @@ La validación deberá comprobar el dígito verificador mediante Módulo 11:
 
 El RUC con prefijo `20` representa a una persona jurídica en este modelo. Las personas naturales se identificarán mediante DNI, CE o Pasaporte; no se registrará un RUC de persona natural como identificador del subtipo sin una decisión institucional y de modelo posterior.
 
-**Estado:** `CONFIRMADO` para formato y checksum.  
+**Estado:** `CONFIRMADO` para el formato propuesto; checksum en adaptadores simulados: `REQUISITO / PENDIENTE DE IMPLEMENTACIÓN Y EVIDENCIA`.
 **Fuente externa RENIEC/SUNAT:** `PENDIENTE`.
+
 
 ### 5.3 Correos electrónicos
 
@@ -143,7 +144,7 @@ No se aceptarán personas jurídicas como apoderados ni personas naturales como 
 Cada representación debe registrar:
 
 - `fecha_inicio_vigencia`, obligatoria.
-- `fecha_fin_vigencia`, opcional; si existe, debe ser posterior o igual a la fecha de inicio.
+- `fecha_fin_vigencia` (`vigencia_fin`), opcional; si es `NULL`, representa una vigencia indefinida o no determinada según el modelo actual; si existe, debe ser posterior o igual a la fecha de inicio.
 - Tipo o alcance del poder.
 - Número de partida, asiento o documento de SUNARP, cuando exista.
 - Estado de validación de la representación.
@@ -151,7 +152,9 @@ Cada representación debe registrar:
 
 ### 6.3 Prohibición de solapamiento
 
-No se permitirán vigencias superpuestas para el mismo par `id_persona_natural` + `id_persona_juridica` y el mismo poder o alcance.
+La relación debe garantizar unicidad por la dupla `id_persona_natural` + `id_persona_juridica` para el mismo poder o alcance, sin afirmar una relación global 1:1. Una persona natural puede representar a múltiples personas jurídicas y una persona jurídica puede tener múltiples representantes, siempre que las vigencias y alcances aplicables no se superpongan.
+
+No se permitirán vigencias superpuestas para la misma dupla y el mismo poder o alcance.
 
 La restricción se implementará en PostgreSQL mediante una restricción `EXCLUDE` sobre un rango de fechas, o mediante un trigger transaccional equivalente cuando la fecha final sea abierta. Las vigencias abiertas se considerarán activas hasta que sean cerradas o revocadas.
 
@@ -177,6 +180,8 @@ La restricción se implementará en PostgreSQL mediante una restricción `EXCLUD
 - Ninguna contraseña, hash de refresh token ni credencial equivalente aparecerá en logs, respuestas HTTP o mensajes de error.
 - El acceso debe responder de forma uniforme cuando el usuario no exista, la contraseña sea incorrecta o la cuenta esté inactiva, evitando enumeración de cuentas.
 
+**Estado:** `REQUISITO / PROPUESTA / PENDIENTE DE IMPLEMENTACIÓN` para Argon2id efectivo, protección de credenciales y ausencia de tokens en logs, respuestas HTTP o mensajes de error.
+
 ### 7.2 Bloqueo temporal
 
 - Cinco intentos fallidos consecutivos provocan el estado `BLOQUEADA_TEMPORAL`.
@@ -187,7 +192,7 @@ La restricción se implementará en PostgreSQL mediante una restricción `EXCLUD
 - Cumplido el plazo, la cuenta podrá volver a `ACTIVA` mediante una transición controlada, sin borrar el historial de intentos.
 - El desbloqueo administrativo y los cambios de estado deben quedar auditados.
 
-**Estado:** `CONFIRMADO` para cinco intentos y estados.  
+**Estado:** `PENDIENTE — lógica de aplicación` para cinco intentos y estados.
 **Duración exacta del bloqueo:** `PENDIENTE` de aprobación.
 
 ### 7.3 Sesiones y refresh tokens
@@ -203,7 +208,7 @@ La restricción se implementará en PostgreSQL mediante una restricción `EXCLUD
 - La revocación manual, el cierre de sesión y el cambio de contraseña deben invalidar las sesiones según la política institucional aprobada.
 - Los access tokens JWT se firmarán asimétricamente con RS256; las claves privadas se gestionarán fuera del código fuente y los secretos no se incluirán en el repositorio.
 
-**Estado:** `CONFIRMADO` para rotación, hash y detección de reuso.  
+**Estado:** `PENDIENTE / lógica de aplicación` para rotación, hash y detección de reuso.
 **TTL exacto de access/refresh token y gestión de claves:** `PENDIENTE` de aprobación técnica.
 
 ## 8. Casilla electrónica y Ley N.° 29733
@@ -234,7 +239,7 @@ La revocación debe registrarse como un nuevo evento histórico inmutable, vincu
 
 La revocación debe registrar fecha, hora, origen y versión vigente de los términos. Desde su efectividad, el sistema no debe enviar nuevas notificaciones digitales basadas en ese consentimiento, salvo la conservación y atención de obligaciones legales que correspondan.
 
-**Estado:** `CONFIRMADO` para campos, estados y conservación histórica.  
+**Estado:** `PENDIENTE` para evidencia e historial de revocación inmutable.
 **Texto legal definitivo, plazos de conservación y responsable del tratamiento:** `PENDIENTE` de validación institucional.
 
 ## 9. Ofuscación de datos sensibles en APIs públicas
@@ -257,7 +262,7 @@ Reglas adicionales:
 - Las consultas de administración y auditoría deben aplicar autorización explícita para mostrar valores completos.
 - La publicación del RUC jurídico sin ofuscación no autoriza a exponer otros datos personales asociados.
 
-**Estado:** `CONFIRMADO` para reglas de transformación.  
+**Estado:** `PROPUESTO / PENDIENTE DE IMPLEMENTACIÓN` para reglas de transformación.
 **Catálogo definitivo de endpoints públicos y perfiles autorizados:** `PENDIENTE`.
 
 ## 10. Contratos con otros módulos

--- a/backend/docs/levantamiento_de_observaciones/04_plan_levantamiento_observaciones_grupo_4_identicore.md
+++ b/backend/docs/levantamiento_de_observaciones/04_plan_levantamiento_observaciones_grupo_4_identicore.md
@@ -38,7 +38,7 @@ Subsanar las observaciones arquitecturales identificadas en el diagnóstico seni
 
 ## 3. Límites y Criterios de Validación
 
-- No se realizarán consultas activas a servicios con costo (Reniec PIDE / SUNAT) en esta etapa; se implementarán adaptadores simulados (*Mock Services*) que validen la estructura y checksum de DNI/RUC.
+- No se realizarán consultas activas a servicios con costo (Reniec PIDE / SUNAT) en esta etapa; los adaptadores simulados (*Mock Services*) para validar estructura, formato y checksum de DNI/RUC son un requisito pendiente de implementación y evidencia de ejecución.
 - Ninguna contraseña o refresh token en texto plano podrá figurar en logs, respuestas de API o base de datos.
 - Toda decisión técnica se etiquetará según la taxonomía oficial: `CONFIRMADO`, `PROPUESTO`, `PENDIENTE` o `EJEMPLO`.
 
@@ -116,9 +116,9 @@ Las siguientes definiciones se dejan deliberadamente pendientes. IdentiCore no d
 | :---: | :--- | :---: | :--- |
 | **H1 CERRADO** | El análisis funcional documenta personas naturales/jurídicas, representación, consentimiento y privacidad. | Tapullima | `01_analisis_identidad_personas_seguridad.md` |
 | **PENDIENTE** | El modelo separa limpiamente Personas Naturales de Personas Jurídicas e implementa `representacion_legal`. | Jair | `02_modelo_datos_identicore_v2.md` |
-| **COMPLETADO** | Se implementan validaciones de formato estricto para DNI (8 dígitos) y RUC (11 dígitos válidos). | Segundo | `03_esquema_sigd_auth_v2.sql` - restricciones `CHECK chk_persona_natural_dni_format` y `chk_persona_juridica_ruc_format` |
-| **COMPLETADO** | El esquema usa Argon2id y modela `sesion_usuario` con refresh tokens rotativos, control de reuso y auditoría IP/User-Agent. | Segundo | `03_esquema_sigd_auth_v2.sql` y `04_validacion_identicore_v2.md` |
-| **COMPLETADO** | Se modela `consentimiento_datos` con historial de revocación inmutable bajo la Ley N.° 29733. | Jair / Segundo | Modelo, DDL y validación v2.0 |
+| **PROPUESTA / PENDIENTE** | Se requieren validaciones de formato estricto para DNI (8 dígitos) y RUC (11 dígitos válidos). | Segundo | `03_esquema_sigd_auth_v2.sql` - restricciones `CHECK chk_persona_natural_dni_format` y `chk_persona_ruc_format` |
+| **PENDIENTE / LÓGICA DE APLICACIÓN** | Se requiere Argon2id efectivo y gestión de `sesion_usuario` con refresh tokens rotativos, control de reuso y auditoría IP/User-Agent. | Segundo | `03_esquema_sigd_auth_v2.sql` y `04_validacion_identicore_v2.md` |
+| **PENDIENTE** | Se requiere modelar `consentimiento_datos` con historial de revocación inmutable bajo la Ley N.° 29733. | Jair / Segundo | Modelo, DDL y validación v2.0 |
 | **H1 CERRADO** | Se documentan las reglas de ofuscación para consultas públicas. | Tapullima | Matriz de privacidad del análisis funcional |
 | **PENDIENTE** | Diagrama ER actualizado en Draw.io y exportado a PNG. | Jair | Archivos `.drawio` y `.png` |
 | **PENDIENTE** | Decisiones técnicas fundamentadas en el log de IdentiCore. | Segundo | `05_decisiones_levantamiento_identicore.md` |


### PR DESCRIPTION
Cierre de H1 de IdentiCore.

Incluye:
- Corrección del modelo de representación legal.
- Corrección del alcance de ofuscación.
- Bloqueo de cuenta como pendiente de lógica de aplicación.
- Refresh token rotation/reuse como pendiente.
- Revocación inmutable como pendiente de implementación/evidencia.
- Corrección de referencia RUC.
- Ajuste del README al estado real de validación.
- Corrección de checksum/adaptadores como requisito pendiente.
- Corrección de requisitos Argon2id y protección de logs.
- Aclaración de vigencia_fin = NULL.